### PR TITLE
doc: Update nuqs link to the new domain

### DIFF
--- a/apps/app/content/docs/index.mdx
+++ b/apps/app/content/docs/index.mdx
@@ -48,7 +48,7 @@ It extracts cleaned markdown of page content, agent-favoured links tree and page
   across workers, SDKs, and docs. The JS/TS SDK also exposes it at
   `deepcrawl/zod/v4` as an app-level helper can share the same runtime instance.
 - **[React Query](https://tanstack.com/query):** Advanced server-side prefetching and cache synchronization for fast dashboard interactions.
-- **[nuqs](https://nuqs.47ng.com):** URL state serialization supports our advanced custom states management for best efficiency and user experience with shareable custom operation options by copying the URL.
+- **[nuqs](https://nuqs.dev):** URL state serialization supports our advanced custom states management for best efficiency and user experience with shareable custom operation options by copying the URL.
 - **[shadcn/ui](https://ui.shadcn.com) + [Tailwind CSS v4](https://tailwindcss.com):** Beautiful and accessible components system and modern design tokens for consistent UI.
 - **[Drizzle ORM](https://orm.drizzle.team):** Type-safe data layer across both Neon PostgreSQL and Cloudflare D1 SQLite deployments for data persistence.
 - **[Upstash Redis](https://upstash.com) + [Cloudflare KV](https://developers.cloudflare.com/kv):** Rate-limiting and Layered caching strategy that balances hot-path performance with cost control.


### PR DESCRIPTION
Source: https://github.com/47ng/nuqs/pull/1120